### PR TITLE
feat: better input handling

### DIFF
--- a/examples/sample.rs
+++ b/examples/sample.rs
@@ -61,7 +61,8 @@ fn main() -> Result<()> {
                     "You clicked on {}{}!",
                     action.arg,
                     action
-                        .value
+                        .values
+                        .get(&action.input_id.unwrap_or_default())
                         .map_or(String::new(), |value| format!(", input = {}", value))
                 );
                 println!("{}", message);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,8 @@ pub use content::input::Selection;
 pub use content::text::Text;
 use thiserror::Error;
 
-pub mod manager;
-pub use manager::{ActivatedAction, DismissalReason, ToastManager};
+mod manager;
+pub use manager::{ActivatedAction, DismissalReason, ToastDismissed, ToastFailed, ToastManager};
 
 mod toast;
 pub use toast::{Scenario, Toast, ToastDuration};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub use content::input::Selection;
 pub use content::text::Text;
 use thiserror::Error;
 
-mod manager;
+pub mod manager;
 pub use manager::{ActivatedAction, DismissalReason, ToastManager};
 
 mod toast;

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -31,7 +31,7 @@ pub struct ActivatedAction {
     /// The values that were passed to the input fields.
     pub values: HashMap<String, String>,
     /// This is only present if the action was associated with an input field.
-    pub input_id: String,
+    pub input_id: Option<String>,
 }
 
 /// Represents the dismissal of a toast notification.
@@ -171,7 +171,7 @@ impl ToastManager {
     where
         F: FnMut(Option<ActivatedAction>) + Send + 'static,
     {
-        let id = input_id.map_or("".to_string(), |s| s.to_string());
+        let id = input_id.map(|s| s.to_string());
         self.on_activated = Some(TypedEventHandler::new(
             move |tn, args: &Option<IInspectable>| {
                 f(Self::get_activated_action(tn, args, id.clone()));
@@ -184,7 +184,7 @@ impl ToastManager {
     fn get_activated_action(
         toast: &Option<ToastNotification>,
         inspect: &Option<IInspectable>,
-        input_id: String,
+        input_id: Option<String>,
     ) -> Option<ActivatedAction> {
         let tag = toast
             .as_ref()

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use windows::{
     core::{IInspectable, Interface, HSTRING},
     Data::Xml::Dom::XmlDocument,
@@ -26,9 +28,10 @@ pub struct ActivatedAction {
     pub tag: Option<String>,
     /// The argument string that was passed to the action.
     pub arg: String,
-    /// The string that was passed to the input field.
+    /// The values that were passed to the input fields.
+    pub values: HashMap<String, String>,
     /// This is only present if the action was associated with an input field.
-    pub value: Option<String>,
+    pub input_id: String,
 }
 
 /// Represents the dismissal of a toast notification.
@@ -198,18 +201,34 @@ impl ToastManager {
             .map(|s| s.to_string())
             .filter(|s| !s.is_empty());
 
-        let user_input = args
+        let user_input: HashMap<String, String> = args
             .and_then(|args| args.UserInput().ok())
-            .and_then(|value_set| value_set.Lookup(&hs(input_id)).ok())
-            .and_then(|args| args.cast::<IReference<HSTRING>>().ok())
-            .and_then(|args| args.Value().ok())
-            .map(|s| s.to_string())
-            .filter(|s| !s.is_empty());
+            .map(|value_set| {
+                value_set
+                    .into_iter()
+                    .filter_map(|pair| {
+                        // Now, process each key-value pair
+                        if let (Ok(key), Ok(value)) = (pair.Key(), pair.Value()) {
+                            if let Ok(value_ref) = value.cast::<IReference<HSTRING>>() {
+                                if let Ok(value_hstring) = value_ref.Value() {
+                                    let value_str = value_hstring.to_string();
+                                    if !value_str.is_empty() {
+                                        return Some((key.to_string(), value_str));
+                                    }
+                                }
+                            }
+                        }
+                        None
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
 
         Some(ActivatedAction {
             tag,
             arg: button_arg?,
-            value: user_input,
+            values: user_input,
+            input_id,
         })
     }
 

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -207,18 +207,14 @@ impl ToastManager {
                 value_set
                     .into_iter()
                     .filter_map(|pair| {
-                        // Now, process each key-value pair
-                        if let (Ok(key), Ok(value)) = (pair.Key(), pair.Value()) {
-                            if let Ok(value_ref) = value.cast::<IReference<HSTRING>>() {
-                                if let Ok(value_hstring) = value_ref.Value() {
-                                    let value_str = value_hstring.to_string();
-                                    if !value_str.is_empty() {
-                                        return Some((key.to_string(), value_str));
-                                    }
-                                }
-                            }
+                        let key = pair.Key().ok()?.to_string();
+                        let value_ref = pair.Value().ok()?.cast::<IReference<HSTRING>>().ok()?;
+                        let value_str = value_ref.Value().ok()?.to_string();
+
+                        if value_str.is_empty() {
+                            return None;
                         }
-                        None
+                        Some((key, value_str))
                     })
                     .collect()
             })


### PR DESCRIPTION
1. expose all the user input in the form of an object to ActionActivationEvent, along with the input id so the user can still link it to a specific input if necessary.
2. made two structs public so that I don't have to have a wrapper around the original struct.